### PR TITLE
Bump to 1.9.4, bump build, use npmjs upstream

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Checklist
 * [ ] Used a fork of the feedstock to propose changes
 * [ ] Bumped the build number (if the version is unchanged)
 * [ ] Reset the build number to `0` (if the version changed)
-* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
+* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
 * [ ] Ensured the license file is being packaged.
 
 <!--

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 mkdir -p $PREFIX/bin $PREFIX/lib
 
 cp bin/* $PREFIX/bin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "yarn" %}
-{% set version = "1.8.0" %}
+{% set version = "1.9.4" %}
 
 package:
   name: {{ name|lower }}
@@ -8,10 +8,10 @@ package:
 source:
   fn: {{ name }}-v{{ version }}.tar.gz
   url: https://registry.npmjs.org/{{ name }}/-/{{ name }}-{{ version }}.tgz
-  # this is is calculated
-  sha256: 7667eb715077b4bad8e2a832e7084e0e6f1ba54d7280dc573c8f7031a7fb093e
   # this is published on npm
   sha1: 3b82d8446b652775723900b470d966861976924b
+  # this is calculated
+  sha256: 7667eb715077b4bad8e2a832e7084e0e6f1ba54d7280dc573c8f7031a7fb093e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "yarn" %}
 {% set version = "1.8.0" %}
-{% set sha256 = "3d8dc87cae99f7547b82026f818b3a14f0393cfa09337bb9adfb446d50a527a7" %}
 
 package:
   name: {{ name|lower }}
@@ -8,8 +7,11 @@ package:
 
 source:
   fn: {{ name }}-v{{ version }}.tar.gz
-  url: https://github.com/yarnpkg/{{ name }}/releases/download/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://registry.npmjs.org/{{ name }}/-/{{ name }}-{{ version }}.tgz
+  # this is is calculated
+  sha256: 7667eb715077b4bad8e2a832e7084e0e6f1ba54d7280dc573c8f7031a7fb093e
+  # this is published on npm
+  sha1: 3b82d8446b652775723900b470d966861976924b
 
 build:
   number: 0
@@ -21,6 +23,7 @@ requirements:
 test:
   commands:
     - yarn --version
+    - yarn versions
 
 about:
   home: https://yarnpkg.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,10 @@
 {% set version = "1.9.4" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-v{{ version }}.tar.gz
   url: https://registry.npmjs.org/{{ name }}/-/{{ name }}-{{ version }}.tgz
   # this is published on npm
   sha1: 3b82d8446b652775723900b470d966861976924b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 7667eb715077b4bad8e2a832e7084e0e6f1ba54d7280dc573c8f7031a7fb093e
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:


### PR DESCRIPTION
Checklist
* [X] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

this adopts some of the things proposed in #9. I mistakenly pushed directly to this repo, so there's a linux 1.9.4_0 out there, but the others have failed/will fail. Sigh.