### PR TITLE
Ship launcher as yarn.cjs so it works in type:module projects

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,14 +17,25 @@ source:
     sha256: 238d933f5c226cc197bd1dae2ad0c468e157b4cba8ed844f81549ba6db777dc4
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   script:
+    # The upstream launcher ships as bin/yarn.js (a CommonJS bundle). Node
+    # resolves a file's module type from the nearest ancestor package.json, so
+    # inside a project that sets "type": "module" Node loads yarn.js as ESM and
+    # crashes with 'Dynamic require of "util" is not supported'. Renaming it to
+    # bin/yarn.cjs forces CommonJS regardless of any parent package.json; the
+    # shims are repointed to match. We avoid shipping a package.json marker in
+    # $PREFIX/bin because that directory is shared with other packages.
     - if: win
       then:
+        - move bin\yarn.js bin\yarn.cjs
+        - powershell -Command "@('bin\yarn','bin\yarn.cmd','bin\yarn.ps1') | ForEach-Object { (Get-Content $_) -replace 'yarn\.js','yarn.cjs' | Set-Content $_ }"
         - xcopy /s /y bin\* "${{ PREFIX }}\Library\bin\"  || exit 1
       else:
         - mkdir -p "${{ PREFIX }}/bin"
+        - mv bin/yarn.js bin/yarn.cjs
+        - sed -i.bak 's/yarn\.js/yarn.cjs/g' bin/yarn bin/yarn.cmd bin/yarn.ps1 && rm -f bin/*.bak
         - chmod 755 bin/*
         - cp bin/* "${{ PREFIX }}/bin"
 


### PR DESCRIPTION
### Problem

conda-forge's `yarn` ships the upstream launcher as `bin/yarn.js`, a CommonJS bundle. Node resolves a file's module type from the nearest ancestor `package.json`, so when `yarn` is invoked from inside a project whose `package.json` sets `"type": "module"`, Node loads `yarn.js` as ESM and crashes:

```
Error: Dynamic require of "util" is not supported
    at .../bin/yarn.js:4:394
```

This is the same upstream bug tracked here:

- yarnpkg/berry#5831 — `Error: Dynamic require of "util" is not supported`
- yarnpkg/berry#6773 — Dynamic require is not supported after installing yarn
- nodejs/corepack#604 — Corepack doesn't properly set up Yarn in an ESM project (notes that a **global yarn using a `.cjs` file works**, while the bundled `yarn.js` does not)

ESM projects (Vite/ESLint flat config/Vitest, etc.) routinely set `"type": "module"`, so the conda-forge yarn is unusable in them today.

### Fix

Rename the launcher to `bin/yarn.cjs` and repoint the `yarn` / `yarn.cmd` / `yarn.ps1` shims to it. The `.cjs` extension forces CommonJS regardless of any ancestor `package.json`, which is the form Yarn already uses for its own release artifacts (`.yarn/releases/yarn-*.cjs`).

A `package.json` marker (`{"type":"commonjs"}`) was deliberately **not** used, because `$PREFIX/bin` is shared with other packages — it would scope every `.js` there to CommonJS and create a file-ownership conflict.

Build number bumped to 1.

### Verification

Built locally (`noarch: generic`); all recipe tests pass. Manual repro under a `"type": "module"` parent:

```
node bin/yarn.js  --version   # Error: Dynamic require of "util" is not supported
node bin/yarn.cjs --version   # 4.16.0
```

---

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (if the version is unchanged)
- [x] Re-rendered with the latest conda-smithy (no changes produced)
- [x] Ensured the license file is being packaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
